### PR TITLE
display github email page

### DIFF
--- a/lib/auth_web/templates/auth/github_email.html.eex
+++ b/lib/auth_web/templates/auth/github_email.html.eex
@@ -1,0 +1,18 @@
+<section class="w-100 center ph3 tc">
+  <h1> Hi <%= @person.givenName %>!
+  </h1>
+  <img width="128px" src="<%= @person.picture %>"
+    class="center db br2"/>
+  <p class="f3"> Unfortunately we cannot find any email addresses
+  linked to your Github account. This could happen if your email is set
+  as private.
+  <p/>
+
+<a href=https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address""
+class="pointer f3">
+check your email settings documentation to see how
+to make your email public:
+</a>
+  
+
+</section>


### PR DESCRIPTION
ref: https://github.com/dwyl/elixir-auth-github/issues/46#issuecomment-680802984
Check if github auth provide an email for the person.
If not display error page