### PR TITLE
PR: Auto Reject Invalid auth_client_id issue #129

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -15,4 +15,4 @@ config :auth, AuthWeb.Endpoint,
   server: false
 
 # Print only warnings and errors during test
-config :logger, level: :info
+config :logger, level: :warn

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,4 +15,4 @@ config :auth, AuthWeb.Endpoint,
   server: false
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, level: :info

--- a/lib/auth/log.ex
+++ b/lib/auth/log.ex
@@ -130,6 +130,7 @@ defmodule Auth.Log do
     |> Map.delete(:__struct__)
     # avoid leaking personal data (person.email) in logs
     |> Map.delete(:email)
+    |> Useful.flatten_map()
     |> Map.keys()
     |> Enum.map(fn key ->
       unless is_nil(Map.get(map, key)) do

--- a/lib/auth_web/controllers/auth_controller.ex
+++ b/lib/auth_web/controllers/auth_controller.ex
@@ -27,7 +27,7 @@ defmodule AuthWeb.AuthController do
       conn = update_in(conn.assigns, &Map.drop(&1, [:person, :jwt]))
 
       conn
-      |> Auth.Log.error(Map.merge(params, %{status: 401, msg: msg}))
+      |> Auth.Log.error(Map.merge(params  , %{status: 401, msg: msg}))
       |> put_flash(:error, msg)
       # force re-auth as for a different app with different roles, etc.
       |> index(params)
@@ -45,7 +45,7 @@ defmodule AuthWeb.AuthController do
         redirect_or_render(conn, conn.assigns.person, nil)
 
       client_id ->
-        msg = "index/2:48 request with client_id: " <> client_id
+        msg = "request with client_id: #{client_id} (index:48)"
         Auth.Log.info(conn, Map.merge(params, %{msg: msg}))
 
         case Auth.Apikey.decode_decrypt(client_id) do

--- a/lib/auth_web/controllers/auth_controller.ex
+++ b/lib/auth_web/controllers/auth_controller.ex
@@ -81,16 +81,11 @@ defmodule AuthWeb.AuthController do
 
   def get_state(conn, params) do
     params_person = Map.get(params, "person")
-
-    state =
-      if not is_nil(params_person) and Map.has_key?(params_person, "state") do
-        Map.get(params_person, "state")
-      else
-        get_referer(conn)
-      end
-
-    Auth.Log.info(conn, Map.merge(params, %{msg: "get_state/2:91 state: #{state}"}))
-    state
+    if not is_nil(params_person) and Map.has_key?(params_person, "state") do
+      Map.get(params_person, "state")
+    else
+      get_referer(conn)
+    end
   end
 
   def get_email(params) do

--- a/lib/auth_web/controllers/auth_controller.ex
+++ b/lib/auth_web/controllers/auth_controller.ex
@@ -64,11 +64,12 @@ defmodule AuthWeb.AuthController do
   def index(conn, params) do
     email = get_email(params)
     state = get_state(conn, params)
+    Auth.Log.info(conn, Map.merge(params, %{msg: "index/2:67 state: #{state}"}))
     oauth_github_url = ElixirAuthGithub.login_url(%{scopes: ["user:email"], state: state})
     oauth_google_url = ElixirAuthGoogle.generate_oauth_url(conn, state)
 
     conn
-    |> Auth.Log.info(Map.merge(params, %{msg: "index/2:68 state: #{state}"}))
+    |> Auth.Log.info(Map.merge(params, %{msg: "index/2:72 state: #{state}"}))
     |> assign(:action, Routes.auth_path(conn, :login_register_handler))
     |> render("index.html",
       oauth_github_url: oauth_github_url,

--- a/lib/auth_web/controllers/auth_controller.ex
+++ b/lib/auth_web/controllers/auth_controller.ex
@@ -76,6 +76,7 @@ defmodule AuthWeb.AuthController do
         else
           msg = "auth_client_id: #{client_id} is not valid (index:77)"
           Auth.Log.error(conn, Map.merge(params, %{msg: msg}))
+
           conn
           |> put_flash(:error, msg)
           |> unauthorized(msg)
@@ -150,7 +151,10 @@ defmodule AuthWeb.AuthController do
   end
 
   def append_client_id(ref, client_id) do
-    ref <> "?auth_client_id=" <> client_id
+    if is_nil(client_id) or
+         client_id == 0,
+       do: ref,
+       else: "#{ref}?auth_client_id=#{client_id}"
   end
 
   def get_referer(conn) do

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Auth.Mixfile do
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
+        c: :test,
         coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
@@ -98,6 +99,7 @@ defmodule Auth.Mixfile do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
+      c: ["coveralls.html"],
       "ecto.setup": ["ecto.create --quiet", "ecto.migrate --quiet", "seeds"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       seeds: ["run priv/repo/seeds.exs"],

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule Auth.Mixfile do
       # Base58 Encodeing: https://github.com/dwyl/base58
       {:B58, "~> 1.0", hex: :b58},
       # Useful functions: https://github.com/dwyl/useful
-      {:useful, "~> 0.1.0"},
+      {:useful, "~> 0.2.0"},
 
       # Ping to Wake Heroku Instance: https://github.com/dwyl/ping
       {:ping, "~> 1.0.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -58,5 +58,5 @@
   "stream_data": {:hex, :stream_data, "0.4.3", "62aafd870caff0849a5057a7ec270fad0eb86889f4d433b937d996de99e3db25", [:mix], [], "hexpm", "7dafd5a801f0bc897f74fcd414651632b77ca367a7ae4568778191fc3bf3a19a"},
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.5.0", "8516502659002cec19e244ebd90d312183064be95025a319a6c7e89f4bccd65b", [:rebar3], [], "hexpm", "d48d002e15f5cc105a696cf2f1bbb3fc72b4b770a184d8420c8db20da2674b38"},
-  "useful": {:hex, :useful, "0.1.0", "0b5813196064176d8de31fc54204651f8ee11c66051afe4d9999006118fb002a", [:mix], [], "hexpm", "77d6214ec6eac2f4ab5bd65ba09e471782a7d0b3d8a2b0b1e2557eb77579a0a1"},
+  "useful": {:hex, :useful, "0.2.0", "5af530a0fc8d5ecece48f3a97c7b37e25d17fc795e6d387f7a4b970819a0b20f", [:mix], [], "hexpm", "0ddb4af90a8fe11b82ab5dba8d156419c6d949915154c933ed154ebcd2deb3be"},
 }

--- a/test/auth/log_test.exs
+++ b/test/auth/log_test.exs
@@ -5,11 +5,13 @@ defmodule Auth.LogTest do
 
   test "E2E Test Auth.Log.error/2 inserts error log into db", %{conn: conn} do
     {:ok, role} = Auth.Role.create_role(%{name: "test", desc: "test", app_id: 1})
-    conn = conn
-    |> non_admin_login()
-    |> put_req_header("content-type", "text/html")
-    |> Auth.UserAgent.assign_ua()
-    |> get(Routes.role_path(conn, :edit, role))
+
+    conn =
+      conn
+      |> non_admin_login()
+      |> put_req_header("content-type", "text/html")
+      |> Auth.UserAgent.assign_ua()
+      |> get(Routes.role_path(conn, :edit, role))
 
     assert conn.status == 404
 

--- a/test/auth_web/controllers/auth_controller_test.exs
+++ b/test/auth_web/controllers/auth_controller_test.exs
@@ -109,7 +109,7 @@ defmodule AuthWeb.AuthControllerTest do
     conn =
       conn
       |> put_req_header("referer", "http://localhost/admin")
-      |> get("/?auth_client_id=42")
+      |> get("/?auth_client_id=#{AuthPlug.Token.client_id()}")
 
     assert conn.resp_body =~ "state=http://localhost/admin"
   end
@@ -124,6 +124,19 @@ defmodule AuthWeb.AuthControllerTest do
       )
 
     assert conn.resp_body =~ "state=http://localhost/admin"
+  end
+
+  # Fail Early on invalid client_id test for: github.com/dwyl/auth/issues/129
+  test "index/2 (not logged in) invalid auth_client_id", %{conn: conn} do
+    conn =
+      conn
+      |> get(
+        "/?referer=" <>
+          URI.encode("http://localhost/admin") <>
+          "&auth_client_id=" <> String.slice(AuthPlug.Token.client_id(), 0..-2)
+      )
+
+    assert html_response(conn, 401) =~ "not valid"
   end
 
   test "get_client_secret(client_id, state) gets the secret for the given client_id" do

--- a/test/auth_web/controllers/auth_controller_test.exs
+++ b/test/auth_web/controllers/auth_controller_test.exs
@@ -109,7 +109,7 @@ defmodule AuthWeb.AuthControllerTest do
     conn =
       conn
       |> put_req_header("referer", "http://localhost/admin")
-      |> get("/")
+      |> get("/?auth_client_id=42")
 
     assert conn.resp_body =~ "state=http://localhost/admin"
   end

--- a/test/auth_web/controllers/auth_controller_test.exs
+++ b/test/auth_web/controllers/auth_controller_test.exs
@@ -116,8 +116,8 @@ defmodule AuthWeb.AuthControllerTest do
 
   test "get_referer/1 query_string", %{conn: conn} do
     conn =
-      conn
-      |> get(
+      get(
+        conn,
         "/?referer=" <>
           URI.encode("http://localhost/admin") <>
           "&auth_client_id=" <> AuthPlug.Token.client_id()
@@ -129,8 +129,8 @@ defmodule AuthWeb.AuthControllerTest do
   # Fail Early on invalid client_id test for: github.com/dwyl/auth/issues/129
   test "index/2 (not logged in) invalid auth_client_id", %{conn: conn} do
     conn =
-      conn
-      |> get(
+      get(
+        conn,
         "/?referer=" <>
           URI.encode("http://localhost/admin") <>
           "&auth_client_id=" <> String.slice(AuthPlug.Token.client_id(), 0..-2)

--- a/test/auth_web/controllers/auth_controller_test.exs
+++ b/test/auth_web/controllers/auth_controller_test.exs
@@ -139,6 +139,11 @@ defmodule AuthWeb.AuthControllerTest do
     assert html_response(conn, 401) =~ "not valid"
   end
 
+  # regression test for: https://github.com/dwyl/auth/issues/135
+  test "append_client_id/2 unit test" do
+    assert AuthWeb.AuthController.append_client_id("ref", nil) == "ref"
+  end
+
   test "get_client_secret(client_id, state) gets the secret for the given client_id" do
     {:ok, app} = Auth.App.create_app(@app_data)
     key = List.first(app.apikeys)

--- a/test/auth_web/controllers/role_controller_test.exs
+++ b/test/auth_web/controllers/role_controller_test.exs
@@ -313,7 +313,8 @@ defmodule AuthWeb.RoleControllerTest do
 
     Auth.Person.create_person(wrong_person_data)
 
-    conn = conn
+    conn =
+      conn
       |> AuthPlug.create_jwt_session(wrong_person_data)
       # |> AuthWeb.RoleController.revoke(%{"people_roles_id" => 1})
       |> post(Routes.role_path(conn, :revoke, 1))


### PR DESCRIPTION
This Pull Request:

+ [x] adds a check for `client_id` validity in `AuthWeb.AuthController.index/2` to allow the controller to _fail_ fast when the `client_id` (`AUTH_API_KEY`) is not valid. fixes #129 