### PR TITLE
Investigat Internal Server Error on dwylauth.herokuapp.com issue #165

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,7 @@ defmodule Auth.Mixfile do
       # https://github.com/dwyl/elixir-auth-google
       {:elixir_auth_google, "~> 1.6.1"},
       # https://github.com/dwyl/auth_plug
-      {:auth_plug, "~> 1.4.0"},
+      {:auth_plug, "~> 1.4.6"},
       # https://github.com/dwyl/rbac
       {:rbac, "~> 0.5.3"},
 


### PR DESCRIPTION
+ [x] update auth_plug in mix.exs to 1.4.6 for #165

@SimonLab if you look at the logs: https://dashboard.heroku.com/apps/dwylauth/logs for an authentication request on https://dwylauth.herokuapp.com/ you'll notice that the _full_ `AUTH_API_KEY` is being logged in the event of an error. i.e. the `AuthPlug.Token.client_id/0` is not doing the split correctly with the `auth_url` appended to the end of the key.

So I suspect that simply updating the version of `auth_plug` to latest will fix the internal server error. 🤞 