### PR TITLE
add scope repo for oauth with Github

### DIFF
--- a/lib/auth_web/controllers/auth_controller.ex
+++ b/lib/auth_web/controllers/auth_controller.ex
@@ -62,7 +62,10 @@ defmodule AuthWeb.AuthController do
   def render_login_buttons(conn, _params) do
     # create referer to consumer app or auth app
     referer = get_referer(conn)
-    oauth_github_url = ElixirAuthGithub.login_url(%{scopes: ["user:email"], state: referer})
+
+    oauth_github_url =
+      ElixirAuthGithub.login_url(%{scopes: ["user:email", "repo"], state: referer})
+
     oauth_google_url = ElixirAuthGoogle.generate_oauth_url(conn, referer)
 
     conn


### PR DESCRIPTION
ref: https://github.com/dwyl/auth/issues/182

This PR add manually the "repo" scope which gives read/write access to repository when using oauth token.