### PR TITLE
Remove unused functions

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,7 +43,6 @@ if config_env() == :prod do
   host = System.get_env("PHX_HOST") || "example.com"
   port = String.to_integer(System.get_env("PORT") || "4000")
 
-
   config :auth, AuthWeb.Endpoint,
     url: [host: host, port: 443],
     http: [

--- a/lib/auth/apikey.ex
+++ b/lib/auth/apikey.ex
@@ -29,15 +29,6 @@ defmodule Auth.Apikey do
   end
 
   @doc """
-  `create_api_key/1` uses the `encrypt_encode/1` to create an API Key
-  that is just two strings joined with a forwardslash ("/").
-  This allows us to use a *single* environment variable.
-  """
-  def create_api_key(id) do
-    encrypt_encode(id) <> "/" <> encrypt_encode(id)
-  end
-
-  @doc """
   `decode_decrypt/1` accepts a `key` and attempts to Base58.decode
   followed by AES.decrypt it. If decode or decrypt fails, return 0 (zero).
   """
@@ -49,10 +40,6 @@ defmodule Auth.Apikey do
       _ ->
         {:error, "invalid key"}
     end
-  end
-
-  def decrypt_api_key(key) do
-    key |> String.split("/") |> List.first() |> decode_decrypt()
   end
 
   def changeset(apikey, attrs) do

--- a/lib/auth/init/roles.ex
+++ b/lib/auth/init/roles.ex
@@ -1,62 +1,66 @@
 defmodule Auth.InitRoles do
-
   def roles do
     [
       %{
-        name: "superadmin", 
-        desc: "With great power comes great responsibility", 
+        name: "superadmin",
+        desc: "With great power comes great responsibility",
         person_id: 1,
         # id: 1,
         permissions: "grant_admin_role"
       },
       %{
-        name: "admin", 
-        desc: "Can perform all system administration tasks", 
+        name: "admin",
+        desc: "Can perform all system administration tasks",
         person_id: 1,
         # id: 2,
         permissions: "manage_people, grant_non_admin_role"
       },
       %{
-        name: "moderator", 
-        desc: "Can view and neutrally moderate any content. Can ban rule-breakers. Cannot delete.", 
+        name: "moderator",
+        desc:
+          "Can view and neutrally moderate any content. Can ban rule-breakers. Cannot delete.",
         person_id: 1,
         # id: 3,
-        permissions: "edit_any_content, lock_content, unpublish_content, ban_rule_breaking_people, view_deleted"
+        permissions:
+          "edit_any_content, lock_content, unpublish_content, ban_rule_breaking_people, view_deleted"
       },
       %{
-        name: "creator", 
-        desc: "Can create any content. Can edit and delete their own content.", 
+        name: "creator",
+        desc: "Can create any content. Can edit and delete their own content.",
         person_id: 1,
         # id: 4,
-        permissions: "create_content, upload_images, edit_own_content, delete_own_content, invite_people"
+        permissions:
+          "create_content, upload_images, edit_own_content, delete_own_content, invite_people"
       },
       %{
-        name: "commenter", 
-        desc: "Can comment on content where commenting is available.", 
+        name: "commenter",
+        desc: "Can comment on content where commenting is available.",
         person_id: 1,
         # id: 5,
         permissions: "comment, flag_comments, flag_content"
       },
       %{
-        name: "subscriber", 
-        desc: "Subscribes for updates e.g. newsletter or content from a specific person. Cannot comment until verified.", 
+        name: "subscriber",
+        desc:
+          "Subscribes for updates e.g. newsletter or content from a specific person. Cannot comment until verified.",
         person_id: 1,
         # id: 6,
         permissions: "subscribe, give_feedback"
       },
       %{
-        name: "banned", 
-        desc: "Can still login to see their content but cannot perform any other action.", 
+        name: "banned",
+        desc: "Can still login to see their content but cannot perform any other action.",
         person_id: 1,
         # id: 7,
         permissions: "view_content, view_profile, delete_own_content, delete_own_profile"
       },
       %{
-        name: "app_admin", 
-        desc: "Can manage their own App(s).", 
+        name: "app_admin",
+        desc: "Can manage their own App(s).",
         person_id: 1,
         # id: 8,
-        permissions: "manage_own_apps, create_content, upload_images, edit_own_content, delete_own_content, invite_people"
+        permissions:
+          "manage_own_apps, create_content, upload_images, edit_own_content, delete_own_content, invite_people"
       }
     ]
   end

--- a/lib/auth/init/statuses.ex
+++ b/lib/auth/init/statuses.ex
@@ -1,104 +1,104 @@
 defmodule Auth.InitStatuses do
-
   def statuses do
     [
       %{
-        text: "verified", 
+        text: "verified",
         id: "1",
         desc: "People are verified once they confirm their email address"
       },
       %{
-        text: "uncategorized", 
+        text: "uncategorized",
         id: "2",
         desc: "All items are uncategorized when they are first created. (Yes, US spelling)"
       },
       %{
-        text: "active", 
+        text: "active",
         id: "3",
         desc: "An App, Item or Person can be active; this is the default state for an App"
       },
       %{
-        text: "done", 
+        text: "done",
         id: "4",
         desc: "Items marked as done are complete"
       },
       %{
-        text: "flagged", 
+        text: "flagged",
         id: "5",
         desc: "A flagged App, Item or Person requires admin attention"
       },
       %{
-        text: "deleted", 
+        text: "deleted",
         id: "6",
-        desc: "Soft-deleted items that no longer appear in UI but are kept for audit trail purposes"
+        desc:
+          "Soft-deleted items that no longer appear in UI but are kept for audit trail purposes"
       },
       %{
-        text: "pending", 
+        text: "pending",
         id: "7",
         desc: "When an email or item is ready to be started/sent is still pending"
       },
       %{
-        text: "sent", 
+        text: "sent",
         id: "8",
         desc: "An email that has been sent but not yet opened"
       },
       %{
-        text: "opened", 
+        text: "opened",
         id: "9",
         desc: "When an email is opened by the recipient"
       },
       %{
-        text: "bounce_transient", 
+        text: "bounce_transient",
         id: "10",
         desc: "Temporary email bounce e.g. because inbox is full"
       },
       %{
-        text: "bounce_permanent", 
+        text: "bounce_permanent",
         id: "11",
         desc: "Permanent email bounce e.g. when inbox doesn't exist"
       },
       %{
-        text: "OK", 
+        text: "OK",
         id: "200",
         desc: "successful HTTP request"
       },
       %{
-        text: "Temporary Redirect", 
+        text: "Temporary Redirect",
         id: "307",
         desc: "the request should be repeated with another URI"
       },
       %{
-        text: "Permanent Redirect", 
+        text: "Permanent Redirect",
         id: "308",
         desc: "all future requests should be directed to the given URI"
       },
       %{
-        text: "Bad Request", 
+        text: "Bad Request",
         id: "400",
         desc: "server cannot or will not process the request due to an apparent client error"
       },
       %{
-        text: "Unauthorized", 
+        text: "Unauthorized",
         id: "401",
         desc: "when authentication is required and has failed"
       },
       %{
-        text: "Forbidden", 
+        text: "Forbidden",
         id: "403",
         desc: "request forbidden"
       },
       %{
-        text: "Not Found", 
+        text: "Not Found",
         id: "404",
         desc: "requested resource could not be found"
       },
       %{
-        text: "Too Many Requests", 
+        text: "Too Many Requests",
         id: "429",
         desc: "has sent too many requests in a given amount of time"
       },
       %{
-        text: "Internal Server Error", 
+        text: "Internal Server Error",
         id: "500",
         desc: "an unexpected condition was encountered"
       }

--- a/lib/auth/people_roles.ex
+++ b/lib/auth/people_roles.ex
@@ -100,13 +100,14 @@ defmodule Auth.PeopleRoles do
   `upsert/4` grants a role (`role_id`) to the given person (`grantee_id`)
   for the `app_id`.
   `granter_id` is the id of the person (admin) granting the role.
-  
+
   """
   def upsert(app_id, grantee_id, granter_id, role_id) do
     case get_roles_for_person_for_app(app_id, grantee_id) do
       # if there are no roles for the person, insert it:
       n when n in [nil, []] ->
         [insert(app_id, grantee_id, granter_id, role_id)]
+
       roles ->
         # if the role exists in the list of roles, return the list
         if Enum.find_value(roles, fn r -> r.id == role_id end) do
@@ -116,7 +117,6 @@ defmodule Auth.PeopleRoles do
         end
     end
   end
-
 
   @doc """
   `revoke/3` grants a role to the given person

--- a/lib/auth_web/controllers/init_controller.ex
+++ b/lib/auth_web/controllers/init_controller.ex
@@ -5,18 +5,18 @@ defmodule AuthWeb.InitController do
   @env_optional ~w/EMAIL_APP_URL GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET/
 
   def index(conn, _params) do
-
-    init = if Envar.is_set_all?(@env_required) do
-      # check_app()
-      Auth.Init.main()
-    else
-      "cannot be run until all required environment variables are set"
-    end
+    init =
+      if Envar.is_set_all?(@env_required) do
+        # check_app()
+        Auth.Init.main()
+      else
+        "cannot be run until all required environment variables are set"
+      end
 
     conn
     # |> assign(:env, check_env())
     |> render(:index,
-      layout: {AuthWeb.InitView, "init_layout.html"}, 
+      layout: {AuthWeb.InitView, "init_layout.html"},
       env: check_env(@env_required),
       env_optional: check_env(@env_optional),
       init: init,
@@ -33,11 +33,12 @@ defmodule AuthWeb.InitController do
   defp api_key_set?() do
     case AuthPlug.Token.api_key() do
       # coveralls-ignore-start
-      nil -> 
+      nil ->
         # IO.puts("AuthPlug.Token.api_key() #{AuthPlug.Token.api_key()}")
         false
+
       # coveralls-ignore-stop
-        
+
       key ->
         String.length(key) > 1
     end

--- a/test/auth/apikey_test.exs
+++ b/test/auth/apikey_test.exs
@@ -23,21 +23,6 @@ defmodule Auth.ApikeyTest do
       assert app_id == id
     end
 
-    test "create_api_key/1 creates an AUTH_API_KEY" do
-      app_id = 123_456_789
-      key = Auth.Apikey.create_api_key(app_id)
-      assert key =~ "/"
-      parts = String.split(key, "/")
-      assert Auth.Apikey.decode_decrypt(List.first(parts)) == {:ok, app_id}
-    end
-
-    test "decrypt_api_key/1 decrypts an AUTH_API_KEY" do
-      app_id = 1234
-      key = Auth.Apikey.create_api_key(app_id)
-      {:ok, decrypted} = Auth.Apikey.decrypt_api_key(key)
-      assert decrypted == app_id
-    end
-
     test "decode_decrypt/1 with invalid client_id" do
       valid_key = Auth.Apikey.encrypt_encode(1)
       {:ok, app_id} = Auth.Apikey.decode_decrypt(valid_key)

--- a/test/auth/init/init_test.exs
+++ b/test/auth/init/init_test.exs
@@ -3,17 +3,17 @@ defmodule Auth.InitTest do
 
   describe "Initialize the Auth Database" do
     test "main/0" do
-      Envar.set("MIX_ENV", "test") 
+      Envar.set("MIX_ENV", "test")
       assert Auth.Init.main() == :ok
     end
-  
+
     test "Delete Everything and init again! (test branches)" do
-      Envar.set("MIX_ENV", "test") 
+      Envar.set("MIX_ENV", "test")
       app = Auth.App.get_app!(1)
       Auth.App.delete_app(app)
       person = Auth.Init.create_admin()
       Auth.Person.delete(person)
-      
+
       assert Auth.Init.main() == :ok
     end
   end


### PR DESCRIPTION
While reviewing how the auth api keys are created (see https://github.com/dwyl/auth/issues/268#issuecomment-1428117773) I noticed a couple of functions that we are not using anymore:

- Remove `create_api_key` and `decrypt_api_key` functions
- run `mix format`

This PR might not be 100% as we're going to rewrite the auth app but it might help us cleaning which code we want to keep/remove on the next version.
Feel free to close it if you think it's not enough useful